### PR TITLE
Fix SCHEMA_COREPROPERTIES

### DIFF
--- a/library/ZendSearch/Lucene/Document/AbstractOpenXML.php
+++ b/library/ZendSearch/Lucene/Document/AbstractOpenXML.php
@@ -47,7 +47,7 @@ abstract class AbstractOpenXML extends Document
      *
      * @var string
      */
-    const SCHEMA_COREPROPERTIES = 'http://schemas.openxmlformats.org/package/2006/metadata/core-properties';
+    const SCHEMA_COREPROPERTIES = 'http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties';
 
     /**
      * Xml Schema - Dublin Core


### PR DESCRIPTION
In https://github.com/butonic/ZendSearch/commit/d3e746ae542bb32220b9a779921a2a2633fefab0
the “/relationships” part of the path was incorrectly removed from
SCHEMA_COREPROPERTIES, causing the internal testsuite to fail (the title
was not parsed correctly any more).

Not running the testsuite after a change, or worse, dropping it
completely, may have unwanted sides effects ;).
